### PR TITLE
docs: fixed wrong env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ Make sure to enable the `user` scope and all subscopes inside of that permission
 #### Add your GitHub username and PAT to `.env` file
 
 Create a `.env` file on the project's root directory or edit `.env.sample` (rename to `.env`) and add your username and PAT.
+
 ```
-USER=YOUR_GITHUB_USERNAME
+GITHUB_USER=YOUR_GITHUB_USERNAME
 TOKEN=YOUR_GITHUB_PERSONAL_ACCESS_TOKEN
 ```
 


### PR DESCRIPTION
Documentation shows incorrect `USER` variable when `GITHUB_USER` is used in the code